### PR TITLE
fix wrong log setting

### DIFF
--- a/webapi/src/main/resources/application.properties
+++ b/webapi/src/main/resources/application.properties
@@ -38,8 +38,8 @@ server.jetty.accesslog.enabled=true
 
 # log 
 logging.level.root=${BELAYER_LOG_LEVEL:WARN}
-logging.level.com.tsurugidb=DEBUG
-logging.level.org.springframework=INFO
+logging.level.com.tsurugidb=${BELAYER_LOG_LEVEL:DEBUG}
+logging.level.org.springframework=${BELAYER_LOG_LEVEL:INFO}
 
 # app
 webapi.application.name=belayer-webapi


### PR DESCRIPTION
Fixed this issue.

* [Issue #639](https://github.com/project-tsurugi/tsurugi-issues/issues/639) belayer-webapiのログレベルが実質固定になっている