### PR TITLE
prepare in advance for scheduled update of tsubakuro

### DIFF
--- a/webapi/src/main/java/com/tsurugidb/belayer/webapi/service/tsubakuro/TsubakuroServiceStub.java
+++ b/webapi/src/main/java/com/tsurugidb/belayer/webapi/service/tsubakuro/TsubakuroServiceStub.java
@@ -240,14 +240,12 @@ public class TsubakuroServiceStub implements TsubakuroService {
         }
 
         @Override
-        public <R> FutureResponse<R> send(int serviceId, @Nonnull byte[] payload, @Nonnull ResponseProcessor<R> processor,
-                boolean background) throws IOException {
+        public <R> FutureResponse<R> send(int serviceId, @Nonnull byte[] payload, @Nonnull ResponseProcessor<R> processor) throws IOException {
             return null;
         }
 
         @Override
-        public <R> FutureResponse<R> send(int serviceId, @Nonnull ByteBuffer payload, @Nonnull ResponseProcessor<R> processor,
-                boolean background) throws IOException {
+        public <R> FutureResponse<R> send(int serviceId, @Nonnull ByteBuffer payload, @Nonnull ResponseProcessor<R> processor) throws IOException {
             return null;
         }
 
@@ -281,6 +279,16 @@ public class TsubakuroServiceStub implements TsubakuroService {
 
         @Override
         public void remove(@Nonnull ServerResource resource) {
+        }
+
+        @Deprecated public <R> FutureResponse<R> send(int serviceId, @Nonnull byte[] payload, @Nonnull ResponseProcessor<R> processor,
+                boolean background) throws IOException {
+            return null;
+        }
+
+        @Deprecated public <R> FutureResponse<R> send(int serviceId, @Nonnull ByteBuffer payload, @Nonnull ResponseProcessor<R> processor,
+                boolean background) throws IOException {
+            return null;
         }
 
     }


### PR DESCRIPTION
tsubakuroの下記API
https://github.com/project-tsurugi/tsubakuro/blob/0563a5ff738a6b9d7a59b6028eec4de46bb81d0e/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/Session.java#L154
https://github.com/project-tsurugi/tsubakuro/blob/0563a5ff738a6b9d7a59b6028eec4de46bb81d0e/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/Session.java#L171
は廃止し、代わりに
https://github.com/project-tsurugi/tsubakuro/blob/0563a5ff738a6b9d7a59b6028eec4de46bb81d0e/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/Session.java#L43
と
https://github.com/project-tsurugi/tsubakuro/blob/0563a5ff738a6b9d7a59b6028eec4de46bb81d0e/modules/session/src/main/java/com/tsurugidb/tsubakuro/common/Session.java#L59
を（Sessionを継承するクラスを作成する必要がある場合は）overrideしてて頂くように変更する予定です。

現在、belayer-webapiの
https://github.com/project-tsurugi/belayer-webapi/blob/80cb9b321cafc31a1df61886887993f209f7b92b/webapi/src/main/java/com/tsurugidb/belayer/webapi/service/tsubakuro/TsubakuroServiceStub.java#L235
では、boolean backgroundのあるsend()のみをoverrideしているので、tsubakuroが変更されるとbuildが失敗するようになります。

本PRでは、boolean backgroundのないsend()を@Overrideするとともに、boolean backgroundのあるsend()の@Overrideタグを除去しています（@Deprecatedも付与しました）。これにより、tsubakuroが更新された場合でもbuildが失敗しないようになります。tsubakuroの更新は、本PRを取り込んで頂いた後に行います。