### PR TITLE
ci: bump actions for deprecation of Node 20

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -37,7 +37,7 @@ jobs:
           ./gradlew -i check
 
       - name: Verify
-        uses: project-tsurugi/tsurugi-annotations-action@v1
+        uses: project-tsurugi/tsurugi-annotations-action@v2
         if: always()
         with:
           junit_input: |

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -37,7 +37,7 @@ jobs:
           sh create_archives.sh
 
       - name: Upload_Artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: belayer-webapi-dists
           path: distribution/dist/*
@@ -63,7 +63,7 @@ jobs:
           rm -fr work
 
       - name: Download_Artifact
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: belayer-webapi-dists
           path: work


### PR DESCRIPTION
This pull request updates CI workflow dependencies to the latest versions of key GitHub Actions in preparation for the upcoming removal of Node 20 from GitHub Actions runners.
- https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/