### PR TITLE
build: introduce Gradle Toolchain Resolver Plugin

### DIFF
--- a/webapi/settings.gradle
+++ b/webapi/settings.gradle
@@ -1,1 +1,5 @@
+plugins {
+  id("org.gradle.toolchains.foojay-resolver-convention") version "0.9.0"
+}
+
 rootProject.name = 'belayer-webapi'


### PR DESCRIPTION
Introduce Toolchain Resolver Plugin for enabling Java toolchain auto-provisioning feature.